### PR TITLE
minor fix in fix doc string

### DIFF
--- a/lwrb/src/lwrb/lwrb.c
+++ b/lwrb/src/lwrb/lwrb.c
@@ -537,7 +537,7 @@ lwrb_skip(lwrb_t* buff, lwrb_sz_t len) {
 }
 
 /**
- * \brief           Get linear address for buffer for fast read
+ * \brief           Get linear address for buffer for fast write
  * \param[in]       buff: Ring buffer instance
  * \return          Linear buffer start address
  */


### PR DESCRIPTION
fix small mistake in docstring of lwrb_get_linear_block_write_address().
Came across this today when I wanted to use memset on lwrb data and it confused me for a second so I thought I'd fix it. 