### PR TITLE
Fix incorrect custom include directory variable reference in library.cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Rework library CMake with removed INTERFACE type
 - Fix the platformio library package description
 - Remove the redundant checks for peek. Introduce the peek tests
-- Fix incorrect `LWPKT_CUSTOM_INC_DIR` reference in `library.cmake` (copy-paste bug from lwpkt)
+- Fix incorrect `LWPKT_CUSTOM_INC_DIR` reference in `library.cmake`
 
 ## v3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Rework library CMake with removed INTERFACE type
 - Fix the platformio library package description
 - Remove the redundant checks for peek. Introduce the peek tests
+- Fix incorrect `LWPKT_CUSTOM_INC_DIR` reference in `library.cmake` (copy-paste bug from lwpkt)
 
 ## v3.2.0
 

--- a/lwrb/library.cmake
+++ b/lwrb/library.cmake
@@ -26,7 +26,7 @@ set(lwrb_ex_SRCS
 # Setup include directories
 set(lwrb_include_DIRS
     ${CMAKE_CURRENT_LIST_DIR}/src/include
-    ${LWPKT_CUSTOM_INC_DIR}
+    ${LWRB_CUSTOM_INC_DIR}
 )
 
 # Register library to the system


### PR DESCRIPTION
## Summary

This PR fixes an incorrect variable reference in `lwrb/library.cmake`.

`LWRB_CUSTOM_INC_DIR` is defined in the file, but `lwrb_include_DIRS` was using `LWPKT_CUSTOM_INC_DIR` instead. This appears to be a copy-paste leftover from `lwpkt`.

## Changes

- Replace `LWPKT_CUSTOM_INC_DIR` with `LWRB_CUSTOM_INC_DIR` in `lwrb/library.cmake`
- Update `CHANGELOG.md` to document the fix

## Why this change

Using the wrong variable name means the intended custom include directory is not referenced correctly when configuring the `lwrb` and `lwrb_ex` targets.

## Validation

- Verified CMake configuration locally with:

```bash
cmake -S . -B build-pr-check
